### PR TITLE
wording: Device polls every 30 seconds

### DIFF
--- a/src/model/PCA20065/DeviceBehaviourInfo.tsx
+++ b/src/model/PCA20065/DeviceBehaviourInfo.tsx
@@ -14,7 +14,7 @@ export const DeviceBehaviourInfo = () => (
 			</li>
 			<li>
 				After boot, the device enters a temporary real-time mode for 10 minutes.
-				In this mode, the device polls for configuration changes every 20
+				In this mode, the device polls for configuration changes every 30
 				seconds and sends sensor updates every minute.
 			</li>
 			<li>


### PR DESCRIPTION
Update wording on device behavior, the device
now polls every 30 seconds, previously 20 seconds.

This interval was kept to save bandwidth and battery life.