### PR TITLE
chore: upgrade to NPM v12

### DIFF
--- a/.github/actions/install-npm/action.yml
+++ b/.github/actions/install-npm/action.yml
@@ -1,0 +1,14 @@
+name: Install NPM
+description: >
+  Installs the NPM version required by the `engines.npm` directive in
+  package.json, which is required for the project to build correctly.
+
+runs:
+  using: composite
+  steps:
+    - name: Install NPM
+      shell: bash
+      run: |
+        npmVersion="$(node -p 'require(`${process.env.GITHUB_WORKSPACE}/package.json`).engines.npm')"
+        echo "Installing npm@${npmVersion}"
+        npm install -g "npm@${npmVersion}"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,9 @@ jobs:
           node-version: "22.x"
           cache: "npm"
 
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
+
       - name: Install dependencies
         run: npm ci --no-audit
 

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -27,6 +27,9 @@ jobs:
           node-version: "22.x"
           cache: "npm"
 
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
+
       - name: Install dependencies
         run: npm ci --no-audit
 
@@ -65,6 +68,9 @@ jobs:
         with:
           node-version: "22.x"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit
@@ -125,6 +131,9 @@ jobs:
         with:
           node-version: "22.x"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Semantic release
         run: npx semantic-release

--- a/README.md
+++ b/README.md
@@ -116,3 +116,13 @@ gh variable set MAP_REGION --env ci --body "<mapRegion>"
 gh variable set MAP_NAME --env ci --body "<mapName>"
 gh variable set MAP_API_KEY --env ci --body "<apiKey>"
 ```
+
+## Node & NPM
+
+This project requires Node.js `>=20.0.0` and npm `>=12.0.2 <13` (enforced via
+`check-node-version` on `npm install` and `npm ci`).
+
+The check is skipped during `npm publish` and `npm pack`, because
+`semantic-release` bundles its own npm (`@semantic-release/npm` depends on
+`npm@^11.6.2`) and runs the publish with that version rather than the one
+installed in CI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "bootstrap": "5.3.8",
         "cdk": "2.1111.0",
         "chalk": "5.6.2",
+        "check-node-version": "4.2.1",
         "commitlint": "19.8.1",
         "glob": "11.1.0",
         "husky": "9.1.7",
@@ -73,7 +74,7 @@
       },
       "engines": {
         "node": ">=20.0.0",
-        "npm": ">=9.0.0"
+        "npm": ">=12.0.2 <13"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5340,6 +5341,51 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/check-node-version": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
+      "integrity": "sha512-YYmFYHV/X7kSJhuN/QYHUu998n/TRuDe8UenM3+m5NrkiH670lb9ILqHIvBencvJc4SDh+XcbXMR4b+TtubJiw==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "chalk": "^3.0.0",
+        "map-values": "^1.0.1",
+        "minimist": "^1.2.0",
+        "object-filter": "^1.0.2",
+        "run-parallel": "^1.1.4",
+        "semver": "^6.3.0"
+      },
+      "bin": {
+        "check-node-version": "bin.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/check-node-version/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-node-version/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.0.0",
       "dev": true,
@@ -8650,6 +8696,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/map-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-values/-/map-values-1.0.1.tgz",
+      "integrity": "sha512-BbShUnr5OartXJe1GeccAWtfro11hhgNJg6G9/UtWKjVGvV5U4C09cg5nk8JUevhXODaXY+hQ3xxMUKSs62ONQ==",
+      "dev": true,
+      "license": "Public Domain"
+    },
     "node_modules/maplibre-gl": {
       "version": "5.21.1",
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.21.1.tgz",
@@ -9494,6 +9547,13 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/object-filter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-filter/-/object-filter-1.0.2.tgz",
+      "integrity": "sha512-NahvP2vZcy1ZiiYah30CEPw0FpDcSkSePJBMpzl5EQgCmISijiGuJm3SPYp7U+Lf2TljyaIw3E5EgkEx/TNEVA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "vike dev",
     "build": "node --max_old_space_size=8192 ./node_modules/vite/bin/vite.js build --emptyOutDir && cp -v ./manifest.json ./build/client/",
-    "prepare": "husky",
+    "prepare": "husky && case \"$npm_command\" in install|ci) check-node-version --package ;; esac",
     "test": "find ./ -type f -name *.spec.ts -not -path './e2e-tests/*' -not -path './node_modules/*' | xargs npx tsx --test --test-reporter spec",
     "test:e2e": "npx playwright test e2e-tests/",
     "start:e2e": "vite -c e2e-tests/vite.config.e2e.ts",
@@ -71,6 +71,7 @@
     "bootstrap": "5.3.8",
     "cdk": "2.1111.0",
     "chalk": "5.6.2",
+    "check-node-version": "4.2.1",
     "commitlint": "19.8.1",
     "glob": "11.1.0",
     "husky": "9.1.7",
@@ -91,7 +92,7 @@
   },
   "engines": {
     "node": ">=20.0.0",
-    "npm": ">=9.0.0"
+    "npm": ">=12.0.2 <13"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
Require npm `>=12.0.2 <13` for this project (Node.js stays at `>=20.0.0`). It is enforced via
[`check-node-version`](https://www.npmjs.com/package/check-node-version) on `npm install` and `npm ci`.

## Why

npm v12 turns three code-execution paths off by default — most notably the
unauthorized execution of install scripts, which is the primary vector for
supply-chain attacks via compromised dependencies
([GitHub changelog](https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/)):

- **`allowScripts` now defaults to off**, so `npm install` no longer executes
  `preinstall`, `install` or `postinstall` scripts from dependencies unless they
  are explicitly allowed in `package.json`. This also covers `prepare` scripts
  from `git`, `file` and `link` dependencies.
- **`--allow-git` now defaults to `none`**, which closes a code-execution path
  where a git dependency's `.npmrc` could override the git executable, even with
  `--ignore-scripts`.
- **`--allow-remote` now defaults to `none`**, blocking dependencies from remote
  URLs such as HTTPS tarballs.

Pinning `engines.npm` to `>=12.0.2 <13` and failing the install when it is not
met means these protections cannot be silently bypassed by running an older npm
locally or in CI.

## How

- `engines.npm` is set to `>=12.0.2 <13`. `engines.node` is left untouched.
- `check-node-version --package` runs from the `prepare` script, which npm
  executes on `npm install` and `npm ci`.
- CI installs the npm version declared in `engines.npm` through the new
  `.github/actions/install-npm` composite action, added after each
  `actions/setup-node` step.

The check is skipped during `npm publish` and `npm pack`, because `semantic-release` bundles its own npm (`@semantic-release/npm` depends on `npm@^11.6.2`) and runs the publish with that version rather than the one installed in CI.

